### PR TITLE
changed tweener import path

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,7 +1,7 @@
 
 const St = imports.gi.St;
 const Main = imports.ui.main;
-const Tweener = imports.ui.tweener;
+const Tweener = imports.tweener.tweener;
 const Util = imports.misc.util;
 
 let text, button, orgIndicator;


### PR DESCRIPTION
Fix "No JS module 'tweener' found in search path" issue in Gnome 3.38 due tweener moving to a different location